### PR TITLE
Rename drops to reward previews and remove unused categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The plugin uses a `dungeons.yml` file to store dungeon and quest data. An exampl
 
 ### Database Configuration
 
-Preview items for each dungeon are stored in a MySQL database. Configure the connection in `config.yml`:
+Reward previews for each dungeon are stored in a MySQL database. Configure the connection in `config.yml`:
 
 ```yaml
 database:
@@ -39,7 +39,7 @@ database:
   table-prefix: ""
 ```
 
-Administrators can edit the list of preview items in game using `/edit_drops <dungeon_id>`; closing the GUI will persist changes to MySQL.
+Administrators can edit the reward preview in game using `/edit_preview <dungeon_id>`; closing the GUI will persist changes to MySQL.
 
 ### Dungeon Configuration
 

--- a/src/main/java/maks/com/groupDungeonPlugin/GroupDungeonPlugin.java
+++ b/src/main/java/maks/com/groupDungeonPlugin/GroupDungeonPlugin.java
@@ -6,7 +6,7 @@ import maks.com.groupDungeonPlugin.api.PartyIntegrationAPI;
 import maks.com.groupDungeonPlugin.api.PartyManager;
 import maks.com.groupDungeonPlugin.database.DatabaseManager;
 import maks.com.groupDungeonPlugin.commands.DungeonCommand;
-import maks.com.groupDungeonPlugin.commands.DropEditCommand;
+import maks.com.groupDungeonPlugin.commands.PreviewEditCommand;
 import maks.com.groupDungeonPlugin.commands.PartyDungeonCommand;
 import maks.com.groupDungeonPlugin.listeners.GUIListener;
 import maks.com.groupDungeonPlugin.listeners.PortalListener;
@@ -85,7 +85,7 @@ public final class GroupDungeonPlugin extends JavaPlugin {
         // Register commands
         getCommand("party_dungeon").setExecutor(new PartyDungeonCommand(dungeonManager));
         getCommand("dungeon").setExecutor(new DungeonCommand(dungeonManager, guiManager));
-        getCommand("edit_drops").setExecutor(new DropEditCommand(dungeonManager, guiManager));
+        getCommand("edit_preview").setExecutor(new PreviewEditCommand(dungeonManager, guiManager));
 
         // Register listeners
         getServer().getPluginManager().registerEvents(new GUIListener(), this);

--- a/src/main/java/maks/com/groupDungeonPlugin/api/GUIManager.java
+++ b/src/main/java/maks/com/groupDungeonPlugin/api/GUIManager.java
@@ -152,7 +152,7 @@ public class GUIManager {
             lore.add("§7Party Size: §f" + dungeon.getMinPartySize() + "-" + dungeon.getMaxPartySize());
             lore.add("");
             lore.add("§eClick to enter dungeon");
-            lore.add("§eShift + Right Click to view possible drops");
+            lore.add("§eShift + Right Click to view possible rewards");
 
             iconMeta.setLore(lore);
             icon.setItemMeta(iconMeta);
@@ -174,19 +174,19 @@ public class GUIManager {
     }
 
     /**
-     * Opens the drop preview GUI for a player.
+     * Opens the reward preview GUI for a player.
      *
      * @param player The player to show the GUI to
-     * @param dungeonId The ID of the dungeon to show drops for
+     * @param dungeonId The ID of the dungeon to show rewards for
      */
-    public void openDropPreviewGUI(Player player, String dungeonId) {
+    public void openPreviewGUI(Player player, String dungeonId) {
         Dungeon dungeon = dungeonManager.getDungeon(dungeonId);
         if (dungeon == null) return;
         PreviewGUI gui = new PreviewGUI(player, dungeon, dungeonManager, false);
         gui.open();
     }
 
-    public void openDropEditGUI(Player player, String dungeonId) {
+    public void openPreviewEditGUI(Player player, String dungeonId) {
         if (!player.hasPermission("partydungeon.admin")) {
             player.sendMessage("§cYou don't have permission to use this.");
             return;

--- a/src/main/java/maks/com/groupDungeonPlugin/commands/DungeonCommand.java
+++ b/src/main/java/maks/com/groupDungeonPlugin/commands/DungeonCommand.java
@@ -104,7 +104,7 @@ public class DungeonCommand implements CommandExecutor, TabCompleter {
             if (subCommand.equals("preview")) {
                 Dungeon dungeon = dungeonManager.getDungeon(id);
                 if (dungeon != null) {
-                    guiManager.openDropPreviewGUI(player, dungeon.getId());
+                    guiManager.openPreviewGUI(player, dungeon.getId());
                     return true;
                 }
                 
@@ -141,7 +141,7 @@ public class DungeonCommand implements CommandExecutor, TabCompleter {
         player.sendMessage("§e/party_dungeon <category> §7- Open the dungeon selection GUI for a category");
         player.sendMessage("§e/party_dungeon category <id> §7- Open the dungeon selection GUI for a category");
         player.sendMessage("§e/party_dungeon enter <dungeon> §7- Enter a dungeon");
-        player.sendMessage("§e/party_dungeon preview <dungeon> §7- Preview drops for a dungeon");
+        player.sendMessage("§e/party_dungeon preview <dungeon> §7- Preview rewards for a dungeon");
     }
     
     /**

--- a/src/main/java/maks/com/groupDungeonPlugin/commands/PreviewEditCommand.java
+++ b/src/main/java/maks/com/groupDungeonPlugin/commands/PreviewEditCommand.java
@@ -14,20 +14,20 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Admin command for drop editing.
+ * Admin command for editing reward previews.
  */
-public class DropEditCommand implements CommandExecutor, TabCompleter {
+public class PreviewEditCommand implements CommandExecutor, TabCompleter {
     private final DungeonManager dungeonManager;
     private final GUIManager guiManager;
     private static final int debuggingFlag = 1;
 
     /**
-     * Creates a new drop edit command.
+     * Creates a new preview edit command.
      *
      * @param dungeonManager The dungeon manager
      * @param guiManager The GUI manager
      */
-    public DropEditCommand(DungeonManager dungeonManager, GUIManager guiManager) {
+    public PreviewEditCommand(DungeonManager dungeonManager, GUIManager guiManager) {
         this.dungeonManager = dungeonManager;
         this.guiManager = guiManager;
     }
@@ -57,7 +57,7 @@ public class DropEditCommand implements CommandExecutor, TabCompleter {
         }
 
         if (args.length == 0) {
-            player.sendMessage("§cUsage: /edit_drops <dungeon_id>");
+            player.sendMessage("§cUsage: /edit_preview <dungeon_id>");
             listAvailableDungeons(player);
             return true;
         }
@@ -72,11 +72,11 @@ public class DropEditCommand implements CommandExecutor, TabCompleter {
         }
 
         if (debuggingFlag == 1) {
-            player.getServer().getLogger().info("[DropEditCommand] Player " + player.getName() +
-                                               " editing drops for dungeon: " + dungeon.getName());
+            player.getServer().getLogger().info("[PreviewEditCommand] Player " + player.getName() +
+                                               " editing reward preview for dungeon: " + dungeon.getName());
         }
 
-        guiManager.openDropEditGUI(player, dungeonId);
+        guiManager.openPreviewEditGUI(player, dungeonId);
         return true;
     }
 

--- a/src/main/java/maks/com/groupDungeonPlugin/gui/DungeonSelectionGUI.java
+++ b/src/main/java/maks/com/groupDungeonPlugin/gui/DungeonSelectionGUI.java
@@ -179,7 +179,7 @@ public class DungeonSelectionGUI extends GUI {
 
             lore.add("");
             lore.add("§eClick to enter dungeon");
-            lore.add("§eShift + Right Click to view possible drops");
+            lore.add("§eShift + Right Click to view possible rewards");
 
             iconMeta.setLore(lore);
             icon.setItemMeta(iconMeta);
@@ -229,18 +229,18 @@ public class DungeonSelectionGUI extends GUI {
         // Dungeon selection
         Dungeon dungeon = slotToDungeonMap.get(slot);
         if (dungeon != null) {
-            // Shift + Right Click to view drops
+            // Shift + Right Click to view reward preview
             if (event.getClick() == ClickType.SHIFT_RIGHT) {
                 player.closeInventory();
 
-                // Get the plugin instance and open drop preview GUI
+                // Get the plugin instance and open reward preview GUI
                 GroupDungeonPlugin plugin = (GroupDungeonPlugin) Bukkit.getPluginManager().getPlugin("GroupDungeonPlugin");
                 if (plugin != null) {
-                    plugin.getGuiManager().openDropPreviewGUI(player, dungeon.getId());
+                    plugin.getGuiManager().openPreviewGUI(player, dungeon.getId());
 
                     if (debuggingFlag == 1) {
-                        Bukkit.getLogger().info("[DungeonSelectionGUI] Player " + player.getName() + 
-                                               " viewing drops for dungeon: " + dungeon.getName());
+                        Bukkit.getLogger().info("[DungeonSelectionGUI] Player " + player.getName() +
+                                               " viewing rewards for dungeon: " + dungeon.getName());
                     }
                 }
                 return;

--- a/src/main/java/maks/com/groupDungeonPlugin/gui/PreviewGUI.java
+++ b/src/main/java/maks/com/groupDungeonPlugin/gui/PreviewGUI.java
@@ -11,7 +11,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 import java.util.Map;
 
 /**
- * GUI used for displaying and editing preview items for a dungeon.
+ * GUI used for displaying and editing reward preview items for a dungeon.
  */
 public class PreviewGUI extends GUI {
     private final Dungeon dungeon;
@@ -19,7 +19,7 @@ public class PreviewGUI extends GUI {
     private final boolean editable;
 
     public PreviewGUI(Player player, Dungeon dungeon, DungeonManager dungeonManager, boolean editable) {
-        super(player, (editable ? "§8Edit Preview - " : "§8Possible Drops - ") + dungeon.getName(), 54);
+        super(player, (editable ? "§8Edit Rewards - " : "§8Possible Rewards - ") + dungeon.getName(), 54);
         this.dungeon = dungeon;
         this.dungeonManager = dungeonManager;
         this.editable = editable;
@@ -73,7 +73,7 @@ public class PreviewGUI extends GUI {
             }
             dungeonManager.savePreviewItems(dungeon.getId());
             player.closeInventory();
-            player.sendMessage("§aPreview items saved.");
+            player.sendMessage("§aReward preview saved.");
         }
     }
 }

--- a/src/main/java/maks/com/groupDungeonPlugin/listeners/PortalListener.java
+++ b/src/main/java/maks/com/groupDungeonPlugin/listeners/PortalListener.java
@@ -98,27 +98,6 @@ public class PortalListener implements Listener {
         portalLocations.put("fantasy_spire", new PortalLocation("world", -610, -58, -929));
         portalLocations.put("fantasy_citadel", new PortalLocation("world", -605, -58, -929));
 
-        // Elemental Challenges dungeons
-        portalLocations.put("elemental_inferno", new PortalLocation("world", -625, -58, -924));
-        portalLocations.put("elemental_trench", new PortalLocation("world", -620, -58, -924));
-        portalLocations.put("elemental_peaks", new PortalLocation("world", -615, -58, -924));
-        portalLocations.put("elemental_core", new PortalLocation("world", -610, -58, -924));
-        portalLocations.put("elemental_sanctum", new PortalLocation("world", -605, -58, -924));
-
-        // Cosmic Adventures dungeons
-        portalLocations.put("cosmic_belt", new PortalLocation("world", -625, -58, -919));
-        portalLocations.put("cosmic_xeno", new PortalLocation("world", -620, -58, -919));
-        portalLocations.put("cosmic_corridor", new PortalLocation("world", -615, -58, -919));
-        portalLocations.put("cosmic_nexus", new PortalLocation("world", -610, -58, -919));
-        portalLocations.put("cosmic_horizon", new PortalLocation("world", -605, -58, -919));
-
-        // Horror dungeons
-        portalLocations.put("horror_asylum", new PortalLocation("world", -625, -58, -914));
-        portalLocations.put("horror_manor", new PortalLocation("world", -620, -58, -914));
-        portalLocations.put("horror_cemetery", new PortalLocation("world", -615, -58, -914));
-        portalLocations.put("horror_dimension", new PortalLocation("world", -610, -58, -914));
-        portalLocations.put("horror_torment", new PortalLocation("world", -605, -58, -914));
-
         if (debuggingFlag == 1) {
             plugin.getLogger().info("Created " + portalLocations.size() + " default portal locations");
         }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,12 +1,12 @@
 # Database Configuration
 database:
-  host: "localhost"
-  port: 3306
-  dbname: "groupdungeon"
-  user: "dungeon_user"
-  password: "strong_password"
-  pool-size: 10
-  table-prefix: ""
+  host: "localhost"       # MySQL server hostname
+  port: 3306               # MySQL server port
+  dbname: "groupdungeon"  # Database name
+  user: "dungeon_user"    # Database user
+  password: "strong_password" # Database password
+  pool-size: 10            # Maximum connections in the pool
+  table-prefix: ""        # Optional prefix for table names
 
 # Debug Settings
 debug: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -12,9 +12,9 @@ commands:
     aliases: [pd, dungeon]
     permission: partydungeon.use
 
-  edit_drops:
-    description: Admin command for editing dungeon drops
-    usage: /edit_drops <dungeon_id>
+  edit_preview:
+    description: Admin command for editing dungeon reward previews
+    usage: /edit_preview <dungeon_id>
     permission: partydungeon.admin
 
 permissions:


### PR DESCRIPTION
## Summary
- Replace drop terminology with reward previews across commands and GUIs
- Drop admin command renamed to `/edit_preview`
- Remove deprecated elemental/cosmic/horror portal defaults
- Document database connection options in `config.yml`

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a42c070a94832a97edaf7a58e4afca