### PR TITLE
Add configurable quest stages and dynamic warps

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,38 +43,40 @@ Administrators can edit the reward preview in game using `/edit_preview <dungeon
 
 ### Dungeon Configuration
 
+Each dungeon is defined in `dungeons.yml` inside its category. Besides basic
+information like name and level requirements you can now configure keys, warps
+and quest stages:
+
 ```yaml
-dungeons:
-  example-dungeon-id:
-    name: "Example Dungeon"
-    description: "An example dungeon for testing purposes"
-    entrance:
-      world: "world"
-      x: 0
-      y: 64
-      z: 0
-      yaw: 0
-      pitch: 0
-    entry-fee: 100
-    min-party-size: 2
-    max-party-size: 5
-    quests:
-      # Blood difficulty quests
-      blood:
-        example-blood-quest-id:
-          name: "Blood Quest 1"
-          description: "A blood difficulty quest"
-          required-level: 10
-          reward-experience: 100
-          reward-money: 50
-          spawn:
-            world: "world"
-            x: 100
-            y: 64
-            z: 100
-            yaw: 0
-            pitch: 0
+categories:
+  mythology:
+    dungeons:
+      odyssey:
+        name: "The Odyssey of Shadows"
+        description: "Journey through the trials of Odysseus with dark twists"
+        tier: 1
+        requiredLevel: 20
+        minPartySize: 1
+        maxPartySize: 3
+        icon: TRIDENT
+        keyId: TRIPWIRE_HOOK            # optional key material
+        keyDisplayName: "&6Shadow Key"  # optional key display name
+        entryWarp: m1                   # warp used when entering
+        stages:
+          1:
+            description: "Arrive at the haunted shores"
+            warp: m1_s1
+            triggerMob: "Shore Guardian"   # killing this mob advances the stage
+          2:
+            description: "Defeat the shadow cyclops"
+            warp: m1_s2
+            triggerMob: "Shadow Cyclops"
 ```
+
+`entryWarp` sets the warp command executed when the party enters the dungeon.
+Each stage contains a description sent to the party, a warp to teleport to and
+an optional `triggerMob` name. When a mob with that name is killed the stage
+advances automatically.
 
 ## Integration with Party System
 

--- a/src/main/java/maks/com/groupDungeonPlugin/GroupDungeonPlugin.java
+++ b/src/main/java/maks/com/groupDungeonPlugin/GroupDungeonPlugin.java
@@ -9,6 +9,7 @@ import maks.com.groupDungeonPlugin.commands.DungeonCommand;
 import maks.com.groupDungeonPlugin.commands.PreviewEditCommand;
 import maks.com.groupDungeonPlugin.commands.PartyDungeonCommand;
 import maks.com.groupDungeonPlugin.listeners.GUIListener;
+import maks.com.groupDungeonPlugin.listeners.DungeonMobListener;
 import maks.com.groupDungeonPlugin.listeners.PortalListener;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -86,6 +87,7 @@ public final class GroupDungeonPlugin extends JavaPlugin {
         // Register listeners
         getServer().getPluginManager().registerEvents(new GUIListener(), this);
         getServer().getPluginManager().registerEvents(new PortalListener(this, dungeonManager), this);
+        getServer().getPluginManager().registerEvents(new DungeonMobListener(dungeonManager), this);
 
         getLogger().info("GroupDungeonPlugin has been enabled!");
         getLogger().info("Debug mode: " + (getConfig().getInt("debug") == 1 ? "ON" : "OFF"));

--- a/src/main/java/maks/com/groupDungeonPlugin/listeners/DungeonMobListener.java
+++ b/src/main/java/maks/com/groupDungeonPlugin/listeners/DungeonMobListener.java
@@ -1,0 +1,23 @@
+package maks.com.groupDungeonPlugin.listeners;
+
+import maks.com.groupDungeonPlugin.api.DungeonManager;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDeathEvent;
+
+public class DungeonMobListener implements Listener {
+    private final DungeonManager dungeonManager;
+
+    public DungeonMobListener(DungeonManager dungeonManager) {
+        this.dungeonManager = dungeonManager;
+    }
+
+    @EventHandler
+    public void onEntityDeath(EntityDeathEvent event) {
+        Player killer = event.getEntity().getKiller();
+        if (killer == null) return;
+        String name = event.getEntity().getName();
+        dungeonManager.handleMobDeath(killer, name);
+    }
+}

--- a/src/main/java/maks/com/groupDungeonPlugin/models/Dungeon.java
+++ b/src/main/java/maks/com/groupDungeonPlugin/models/Dungeon.java
@@ -26,6 +26,9 @@ public class Dungeon {
     private String keyId;               // Key identifier
     private String keyDisplayName;      // Key display name
 
+    // Warp configuration
+    private String entryWarp;           // Warp used to enter the dungeon
+
     // Preview items mapped by slot
     private Map<Integer, ItemStack> previewItems;
 
@@ -60,6 +63,7 @@ public class Dungeon {
         this.keyDisplayName = null;
         this.previewItems = new HashMap<>();
         this.questStages = new ArrayList<>();
+        this.entryWarp = null;
     }
 
     /**
@@ -93,6 +97,7 @@ public class Dungeon {
         this.keyDisplayName = keyDisplayName;
         this.previewItems = new HashMap<>();
         this.questStages = new ArrayList<>();
+        this.entryWarp = null;
     }
 
     /**
@@ -276,5 +281,13 @@ public class Dungeon {
      */
     public boolean requiresKey() {
         return keyId != null && !keyId.isEmpty();
+    }
+
+    public String getEntryWarp() {
+        return entryWarp;
+    }
+
+    public void setEntryWarp(String entryWarp) {
+        this.entryWarp = entryWarp;
     }
 }

--- a/src/main/java/maks/com/groupDungeonPlugin/models/QuestStage.java
+++ b/src/main/java/maks/com/groupDungeonPlugin/models/QuestStage.java
@@ -7,11 +7,17 @@ public class QuestStage {
     private final int stageNumber;
     private final String description;
     private final String warp;
+    private final String triggerMob;
 
-    public QuestStage(int stageNumber, String description, String warp) {
+    public QuestStage(int stageNumber, String description, String warp, String triggerMob) {
         this.stageNumber = stageNumber;
         this.description = description;
         this.warp = warp;
+        this.triggerMob = triggerMob;
+    }
+
+    public QuestStage(int stageNumber, String description, String warp) {
+        this(stageNumber, description, warp, null);
     }
 
     public int getStageNumber() {
@@ -24,6 +30,10 @@ public class QuestStage {
 
     public String getWarp() {
         return warp;
+    }
+
+    public String getTriggerMob() {
+        return triggerMob;
     }
 }
 

--- a/src/main/resources/dungeons.yml
+++ b/src/main/resources/dungeons.yml
@@ -12,6 +12,16 @@ categories:
         minPartySize: 1
         maxPartySize: 3
         icon: TRIDENT
+        entryWarp: m1
+        stages:
+          1:
+            description: "Arrive at the haunted shores"
+            warp: m1_s1
+            triggerMob: "Shore Guardian"
+          2:
+            description: "Defeat the shadow cyclops"
+            warp: m1_s2
+            triggerMob: "Shadow Cyclops"
       poseidon:
         name: "Poseidon's Mist Isle"
         description: "Navigate the treacherous waters of Poseidon's domain"
@@ -20,6 +30,16 @@ categories:
         minPartySize: 2
         maxPartySize: 4
         icon: HEART_OF_THE_SEA
+        entryWarp: m2
+        stages:
+          1:
+            description: "Secure the misty beach"
+            warp: m2_s1
+            triggerMob: "Mist Sentinel"
+          2:
+            description: "Face the sea serpent"
+            warp: m2_s2
+            triggerMob: "Sea Serpent"
       zeus:
         name: "Mount Olympus"
         description: "Challenge the gods atop Mount Olympus"
@@ -28,6 +48,16 @@ categories:
         minPartySize: 3
         maxPartySize: 5
         icon: LIGHTNING_ROD
+        entryWarp: m3
+        stages:
+          1:
+            description: "Climb the sacred mountain"
+            warp: m3_s1
+            triggerMob: "Olympus Guard"
+          2:
+            description: "Defeat Zeus himself"
+            warp: m3_s2
+            triggerMob: "Zeus"
       daedalus:
         name: "Daedalus' Eternal Labyrinth"
         description: "Find your way through the ever-changing maze"


### PR DESCRIPTION
## Summary
- load entry warp and quest stages from config with optional mob triggers
- track active dungeons, auto-advance stages on kills and finish with timer
- document new YAML fields and add listener for mob deaths

## Testing
- `mvn -q -e package` *(fails: Could not transfer artifact maven-resources-plugin: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a43d1e2b70832a83575647a839684c